### PR TITLE
Make destination_user_id optional.

### DIFF
--- a/definitions/ello_protobufs/notification_service/create_notification_request.proto
+++ b/definitions/ello_protobufs/notification_service/create_notification_request.proto
@@ -9,7 +9,7 @@ import 'ello_protobufs/announcement.proto';
 
 message CreateNotificationRequest {
   required NotificationType type = 1 [default = UNSPECIFIED_TYPE];
-  required uint32 destination_user_id = 2;
+  optional uint32 destination_user_id = 2;
   optional Post post = 3;
   optional User user = 4;
   optional Comment comment = 5;

--- a/lib/ello_protobufs/announcement.pb.rb
+++ b/lib/ello_protobufs/announcement.pb.rb
@@ -5,16 +5,13 @@
 #
 require 'protobuf/message'
 
-##
-# Imports
-#
-
 module ElloProtobufs
 
   ##
   # Message Classes
   #
   class Announcement < ::Protobuf::Message; end
+
 
   ##
   # Message Fields
@@ -30,3 +27,4 @@ module ElloProtobufs
   end
 
 end
+

--- a/lib/ello_protobufs/notification_service/create_notification_request.pb.rb
+++ b/lib/ello_protobufs/notification_service/create_notification_request.pb.rb
@@ -31,7 +31,7 @@ module ElloProtobufs
     #
     class CreateNotificationRequest
       required ::ElloProtobufs::NotificationType, :type, 1, :default => ::ElloProtobufs::NotificationType::UNSPECIFIED_TYPE
-      required :uint32, :destination_user_id, 2
+      optional :uint32, :destination_user_id, 2
       optional ::ElloProtobufs::Post, :post, 3
       optional ::ElloProtobufs::User, :user, 4
       optional ::ElloProtobufs::Comment, :comment, 5

--- a/lib/ello_protobufs/watch.pb.rb
+++ b/lib/ello_protobufs/watch.pb.rb
@@ -30,4 +30,6 @@ module ElloProtobufs
     required :uint64, :created_at, 4
     required :uint64, :updated_at, 5
   end
+
 end
+


### PR DESCRIPTION
This enables us to use existing protocols to send announcements to a
topic.